### PR TITLE
LOG 高度错误

### DIFF
--- a/panel/list.js
+++ b/panel/list.js
@@ -61,7 +61,7 @@ var createItem = function () {
         texture: 'dark',
         fold: true,
         num: 1,
-        translateY: -1000
+        translateY: -10000
     };
 };
 
@@ -88,7 +88,7 @@ exports.methods = {
         dataList.forEach(function (item, i) {
             var source = list[index + i];
             if (!source) {
-                item.translateY = -1000;
+                item.translateY = -10000;
                 return;
             }
             item.type = source.type;
@@ -181,7 +181,7 @@ exports.directives = {
                 if (!dataList[i])
                     dataList.push(createItem());
                 else
-                    dataList[i].translateY = -1000;
+                    dataList[i].translateY = -10000;
             }
 
             this.vm.onScroll({ target: this.vm.$el });

--- a/panel/list.js
+++ b/panel/list.js
@@ -156,12 +156,13 @@ exports.directives = {
             var tc = this.vm.$el.clientHeight;
             var cn = list.length - scrollNumCache;
             scrollNumCache = list.length;
+
+            var scroll;
             if (ts !== 0 && height - tc -ts > 30 * cn) {
-                return this.vm.onScroll({ target: this.vm.$el });
+                scroll = this.vm.$el.scrollTop;
+            } else {
+                scroll = this.vm.$el.scrollTop = height - tc
             }
-
-
-            var scroll = this.vm.$el.scrollTop = height - tc;
 
             var tmp = 0;
             var index = 0;


### PR DESCRIPTION
1. 单个 log 超高的情况下，-1000 的位移量可能捉襟见肘，所以加到了 -10000
2. 在滚动条不在最底部的时候，向上拖动使 console 高度增加不会更新内部的复用 item 数量

https://github.com/cocos-creator/fireball/issues/5439